### PR TITLE
Retry on 403 "Forbidden" errors

### DIFF
--- a/google-cloud-contrib/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageRetryHandler.java
+++ b/google-cloud-contrib/google-cloud-nio/src/main/java/com/google/cloud/storage/contrib/nio/CloudStorageRetryHandler.java
@@ -144,7 +144,10 @@ public class CloudStorageRetryHandler {
    * @return true if exs is a retryable error, otherwise false
    */
   static boolean isRetryable(final StorageException exs) {
-    return exs.isRetryable() || exs.getCode() == 500 || exs.getCode() == 503;
+    // Yes one wouldn't necessarily think of 403 as retriable,
+    // but see https://github.com/broadinstitute/gatk/issues/3735
+    // for reports of 403 being returned in cases when retrying works.
+    return exs.isRetryable() || exs.getCode() == 403 || exs.getCode() == 500 || exs.getCode() == 503;
   }
 
   /**

--- a/google-cloud-contrib/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/CloudStorageReadChannelTest.java
+++ b/google-cloud-contrib/google-cloud-nio/src/test/java/com/google/cloud/storage/contrib/nio/CloudStorageReadChannelTest.java
@@ -95,6 +95,18 @@ public class CloudStorageReadChannelTest {
   }
 
   @Test
+  public void testReadRetryOn403() throws IOException {
+    ByteBuffer buffer = ByteBuffer.allocate(1);
+    when(gcsChannel.read(eq(buffer)))
+        .thenThrow(new StorageException(403, "Forbidden."))
+        .thenReturn(1);
+    assertThat(chan.position()).isEqualTo(0L);
+    assertThat(chan.read(buffer)).isEqualTo(1);
+    assertThat(chan.position()).isEqualTo(1L);
+    verify(gcsChannel, times(2)).read(any(ByteBuffer.class));
+  }
+
+  @Test
   public void testReadRetrySSLHandshake() throws IOException {
     ByteBuffer buffer = ByteBuffer.allocate(1);
     when(gcsChannel.read(eq(buffer)))


### PR DESCRIPTION
Yes, the standard says the client should not retry on 403.
(see eg. https://httpstatuses.com/403)
But that doesn't take into account servers that give us unwarranted
403s.

See https://github.com/broadinstitute/gatk/issues/3735 for context.